### PR TITLE
Remove the parallel commit bools from the protobuf changes

### DIFF
--- a/design/parallel-commit/initial-design.md
+++ b/design/parallel-commit/initial-design.md
@@ -41,8 +41,7 @@ Prewrite requests need to notify TiKV that a transaction is using parallel commi
 ```diff
   message PrewriteRequest {
       // ...
-+     bool use_parallel_commit = ...;
-+     repeated bytes secondaries = ...;
++     repeated bytes secondary_keys = ...;
   }
 ```
 
@@ -63,8 +62,7 @@ We also need to be able to clean up dead parallel commit transactions:
 ```diff
   message CheckTxnStatusResponse {
       // ...
-+     bool use_parallel_commit = ...;
-+     repeated bytes secondaries = ...;
++     repeated bytes secondary_keys = ...;
   }
 ```
 


### PR DESCRIPTION
I think we don't need them since if `secondary_keys` is empty, then we can assume it is not a parallel commit. This means that a transaction with just one key cannot be parallel commit, I don't think it is a problem? If it is, we could either add the primary to the secondary list, or we could make it optional.

PTAL @MyonKeminta 