### PR TITLE
Start a design spec for async commit

### DIFF
--- a/design/async-commit/README.md
+++ b/design/async-commit/README.md
@@ -2,7 +2,7 @@
 
 This directory contains design documentation for async commit. Implementation is in progress, see [project summary](project-summary.md).
 
-Implementation is tracked in a [tracking issue](https://github.com/tikv/sig-transaction/issues/36) and [TiKV project](https://github.com/tikv/tikv/projects/34).
+Implementation is tracked [internally](https://docs.google.com/spreadsheets/d/1W6QYTtd7iG7FWfod9c1j-apYElGiIxKRqvQeiDYpjtY/edit#) at PingCAP.
 
 
 ## Overview
@@ -13,144 +13,36 @@ This modification is sound because the source of truth for whether a transaction
 
 The main difficulty is in choosing a timestamp for the commit ts of the transaction.
 
+See [the design spec](spec.md) for detail.
+
 ## Protocol
 
-This section is a little out of date, refer to [initial-design.md](initial-design.md) for a more up to date version.
+### Prewrite
 
-### Phase 1: reads and writes
+TiDB sends an enhanced prewrite message, with `use_async_commit` set to true, and `secondaries` set to a list of all keys in the transaction, except the primary key.
 
-The client (TiDB) sends `lock` messages to the server (TiKV) for each `SELECT ... FOR UPDATE`. Each lock message has a `for_update_ts`.
+In TiKV, the secondary keys are stored in the lock data structure for the primary key.
 
-Modifications are collected in a buffer and sent as a `prewrite` message. No reads are permitted after prewrite.
+If all prewrite messages are successful, then TiDB can send success to its client without waiting for the commit phase.
 
-The client gets a start TS for the whole transaction which is included with every message.
+TiKV returns a `min_commit_ts` to TiDB in its prewrite response. It will be `0` if async commit could not be used. The timestamp sent to TiDB is the maximum of the timestamps for each key. The minimum commit timestamp for each key is the maximum of the max read ts (i.e., a conservative approximation of the last time the key was read), the start ts of the transaction, and the for_update_ts of the transaction.
 
-For both messages, the server checks validity and writes locally. It then sends an `ack` back to the client. For a read, the read value is returned with the ack. Then the server writes the lock and/or modifications to the RaftStore (a 'consensus write'). After the consensus write completes, the server sends a `response` to the client.
+### Commit
 
-For every lock and modification, the server writes a lock to the key's lock CF; each lock stores a reference to the transaction's primary key. For modifications, we also store a value in the default CF.
-
-For the primary key's lock, we store a list of keys in the transaction and their status (whether the key is locked locally, across all nodes, or unlocked), plus an overall status for the transaction.
-
-TODO multiple regions.
-
-### Phase 2: finalisation (formerly commit)
-
-When the client has `response`s (not `ack`s) for every message in a transaction, it sends a single `finalise` message to the server. The client considers the transaction complete when it sends the `finalise` message, it does not need to wait for a response. The client obtains the commit ts from PD for the finalise message.
-
-When the server receives a `finalise` message, it *commits* the transaction. Committing is guaranteed to succeed.
-
-Possible optimisation: the server could finalise the transaction when the prewrite completes without involving the client (see the resolve lock section).
-
-Writes are added to each key which is written, with the commit ts from the primary key. The server unlocks all keys, primary key last. 
-
-### Reads
-
-On read, if a key is locked, then we must look up the primary key and it's lock which holds the transaction record. We wait for the lock's ttl to expire (based on the read's `for_update_ts`). After the ttl expires, if the key is unlocked, the read can progress. Otherwise we must resolve the lock in some way.
+The commit phase is mostly unchanged, the only difference is that all commit messages are sent asynchronously, including the primary key's.
 
 ### Resolve lock
 
 (Called TSRP in CRDB).
 
-Resolve lock determines a transaction's commit status. If the transaction has been rolled back or committed, there is nothing to do. Otherwise, if every consensus write has succeeded, the transaction is committed. Otherwise, the transaction is considered to have timed out and is rolled back.
+When resolving a lock, TiDB must find the primary key and queries it. If the key is committed, then the transaction has been committed. If the key is locked, then TiKV sends the secondary keys back to TiDB. TiDB must query all of them using a `CheckSecondaryLocks` message. If any are not committed, then the transaction is not committed and must be rolled back.
 
-First we check the txn's state as recorded in the primary key. If it is written to Raft, then we can finalise (something must have failed in finalisation or finalisation was never received). (I think this is only an optimisation, we could skip this step and go straight to the next).
-
-Otherwise, we check each lock, if all locks have state consensus write, then we run finalisation. If any lock is only written locally or has failed, then we must rollback the transaction. NOTE: this might require communicating with other nodes due to keys in other regions.
-
-### Rollback
-
-For each modification in a transaction, add a rollback write to the key and remove the lock. For each read, remove the lock. The primary lock should be removed last.
-
-TODO partial rollback with for_update_ts
-
-
-## Issues
-
-See also [parallel-commit-known-issues-and-solutions.md](parallel-commit-known-issues-and-solutions.md).
-
-### Commit timestamp
-
-See [parallel-commit-known-issues-and-solutions.md](globally-non-unique-timestamps.md) for discussion.
-
-In the happy path, there is no problem. However, if the finalise message is lost then when we resolve the lock and the transaction needs committing, then we need to provide a commit timestamp. Unfortunately it seems there is no good answer for what ts to use.
-
-Consider the following example: transaction 1 with start_ts = 1, prewrite @ ts=2, finalise @ ts=4. Transaction 2 makes a non-locking read at ts = 3. If all goes well, this is fine: the transaction is committed by receiving the finalise message with commit_ts = 4. If the read arrives before commit, it finds the key locked and blocks. After the commit it will read the earlier value since its ts is < the commit ts.
-
-However, if the finalise message is lost, then we must initiate a 'resolve lock' once the lock times out. There are some options; bad ideas:
-
-* Use the prewrite ts: this is unsound because the ts is less than the read's ts and so the read will see different values for the key depending on whether it arrives before or after the commit happening, even though its ts is > than the commit ts. That violates the Read Committed property.
-* Transaction 2 returns an error to TiDB and TiDB gets a new ts from PD and uses that as the commit_ts for the resolve lock request. This has the disadvantage that non-locking reads can block and then fail, and require the reader to resolve locks. This timestamp is also later than the timestamp that transaction 1's client thinks it is, which can lead to RC violation.
-* Get a new ts from PD. This has the problem that TiDB may have reported the transaction as committed at an earlier times stamp to the user, which can lead to RC violation.
-
-Possibly good ideas:
-
-* Record the 'max read ts' for each key. E.g., when the read arrives, we record 3 as the max_read_ts (as long as there is no hight read timestamp). We can then use `max_read_ts + 1` as the commit ts. However, that means that timestamps are no longer unique. It's unclear how much of a problem that is. If it is implemented on disk, then it would increase latency of reads intolerably. If it is implemented in memory it could use a lot of memory and we'd need to handle recovery somehow (we could save memory by storing only a per-node or per-region max read ts).
-* Use a hybrid logical clock (HLC) for timestamps. In this way we can enforce causal consistency rather than linearisability. In effect, the ordering of timestamps becomes partial and if the finalise message is lost then we cannot compare transaction 1's timestamps with transaction 2's timestamps without further resolution. Since this would require changing timestamps everywhere, it would be *a lot* of work. Its also not clear exactly how this would be implemented and how this would affect transaction 2. Seems like at the least, non-locking reads would block.
-
-
-In order to guarantee SI, `commit_ts` of T1 needs to satisfy:
-
-* It is larger than the `start_ts` of any other transaction which has read the old value of a key written by T1.
-* It is smaller than the `start_ts` of any other transaction which reads the new value of any key written by T1.
-
-Note that a transaction executing in parallel with T1 which reads a key written by T1 can have `start_ts` before or after T1's `commit_ts`.
-
-Consider all cases of Parallel Commit:
-
-* Normal execution process: After Prewrite is completed, TiKV will return a response to the client. If it is to take the `commit_ts` asynchronously afterwards, then the client could start a new transaction between the time of receiving the response and the time of TiKV getting a `commit_ts`. The new transaction would therefore read the old value of a key modified by the first transaction which violates RC. A solution is for TiKV to first obtain a timestamp and return that to the client as part of the prewrite response, then use that timestamp to commit.
-* After Prewrite succeeds, the client disappears, but the transaction is successfully committed. How to choose a `commit_ts`? A new timestamp from PD is not communicated to the client. Some timestamp must be persisted in TiKV.
-
-Parallel Commit is considered to be a successful commit after all prewrites are successful. Transactions after this must be able to see it, and transactions before this can not see it. How to guarantee this?
-
-A solution is for tikv to maintain a `max_start_ts`. When a prewrite writes its locks and returns to the client, use `max(max_start_ts for each key) + 1` to submit. If finalisation fails and a client resolves a lock, TiKV can recalculate `commit_ts`.
-
-The essence of solving this type of problem is to postpone operations that may cause errors until the operation is not an error. Two possible solutions are:
-
-* The region records `min_commit_ts`, which is the smallest `commit_ts` of a prewrite of any async commit transaction currently in progress (i.e., between prewrite and commit) may use. Every in-progress transaction must have a `commit_ts >= min_commit_ts`. For every read request to the region, if its `start_ts` is greater than `min_commit_ts`, the read request blocks until `min_commit_ts` is greater than `start_ts`.
-* The above can be refined by shrinking the granularity from a whole region level to a single key. Two implementation options:
-  - The lock is written to memory first, then `max_start_ts` is obtained and then written to raftstore. When reading, first read the lock in the memory. After successfully writing to raftstore, the lock in memory is cleared, and the lock corresponding to the region is cleared when the leader switches.
-  - Use rocksdb as the storage medium for memory lock, first write to rocksdb, then write to raftstore. The implementation is also simple, and the effect is the same as a.
-
-
-### Initiating resolve lock
-
-As touched upon in the commit timestamp section above, it is not clear how resolve lock should be initiated. There are two options:
-
-* TiKV resolves locks automatically.
-* TiKV returns to TiDB which instantiates resolve lock.
-
-The TiKV approach is faster, but it means we have to get a timestamp from PD and that a read might block for a long time. The TiDB approach takes a lot longer, but is more correct.
-
-### Replica read
-
-The above Commit Ts calculation does not consider the replica read situation, consider the following scenario:
-The leader's maxStartTs is 1, and async commit selects 1 + 1 = 2 as commitTs.
-The startTs of replica read is 3, and it should either see the lock or the data with commitTs of 2. However, due to log replication, replica read may fail to read the lock, which will destroy snapshot isolation.
-
-The solution is the same as prewrite solution 1:
-The read index request carries start ts. When region’s min commit ts < req’s start ts, it is necessary to wait for the min commit ts to exceed start ts before responding to the read index.
-
-
-### Change of leader
-
-The above structure is stored in the leader memory. Although there is no such information on the replica, it will interact with the leader, so it is easy to solve. How to solve the transfer leader? No need to solve, because the new leader must submit an entry for the current term to provide read and write services, so all the information in the previous memory will be submitted, and this part of the information is no longer needed.
-
-It should be noted that if the above scheme is adopted, this part of the memory information and pending requests must be processed when the leader changes.
-
-
-### Blocking reads
-
-TODO
-
-### Schema check
-
-The existing 2pc process checks the schema version before issue the final commit command, if we do async commit, we don't have a chance to check the schema version. If it has changed, we may break the index/row consistency.
-
-The above issue only happens if the transaction prewrite phase is too long, exceeds the 2 * ddl_lease time.
 
 ## 1PC
 
-TODO
+Async commit is a generalisation of 1pc. We can reuse some of the async commit work to implement 1pc. 1pc is only possible when all keys touched by a transaction are in the same region and binlog is not being used. TiDB then sets `try_one_pc` in the prewrite message to true.
+
+In TiKV, a 1pc transaction can be committed in the prewrite phase, and no further action is needed. 
 
 ## Possible optimisations
 
@@ -176,4 +68,3 @@ crdb's transaction model is similar to TiDB in that both are inspired by percola
 
 - [Zhao Lei's doc 中文 + en](https://docs.google.com/document/d/1-yn5zyn8NpqXRii9sA5wDcNHL3L0BYVaEFyD-YChX1g/edit#)
 - [CockroachDB blog post](https://www.cockroachlabs.com/blog/parallel-commits/)
-- [nrc's modelling effort](https://github.com/nrc/parcom)

--- a/design/async-commit/spec.md
+++ b/design/async-commit/spec.md
@@ -68,10 +68,57 @@ message LockInfo {
 
 Implemented in TiDB, TiSpark.
 
+The client has configuration for supporting async commit (`tikv-client.async-commit.enable`), supporting 1pc (`enable-one-pc`), forcing external consistency when using async commit (`external-consistency`), and limits on the size (`tikv-client.async-commit.total-key-size-limit`) and number of keys (`tikv-client.async-commit.keys-limit`) in an async commit transaction. When async commit is enabled, a transaction will not use async commit if it exceeds either of the size limits.
+
+TODO prewrite and commit
+
+TODO resolve
+
+TODO fallback
+
+TODO schema check
+
 ## Server
 
 Implemented in TiKV
 
+A lock on disk or in memory has the following new fields: `use_async_commit`, whether the lock belongs to an async commit transaction, `secondaries`, a list of secondary locks only used for the primary key, and `rollback_ts` (see below).
+
+The server maintains a `max_ts`, which is the largest timestamp observed by the server. Note: the concurrency manager was implemented as part of the async commit project, however, here we only describe parts of it actually used for async commit.
+
+If `max_ts` has become out of date (due to some change to the region topology), then the store cannot handle the primary key of transactions using async commit, and must use full 2pc.
+
+### Prewrite
+
+The server iterates over all keys in the request. If a key is locked for async commit by the current transaction, and it is no longer an async commit transaction, then the lock can be overwritten. Each key is locked; for 1pc the lock is kept privately in memory, for 2pc the lock is written to storage. In either case the lock is also kept in memory by the concurrency manager. These in-memory locks are used to block reading while the transaction is live.
+
+The `min_commit_ts` for the key is calculated as the maximum of the transaction's start ts, `for_update_ts`, and `min_commit_ts`, and the `max_ts` of the store. The `min_commit_ts` is written to the lock. The largest `min_commit_ts` of all keys is returned to the client.
+
+Finally, if this is a 1pc transaction, then all writes are committed and any locks are released.
+    
+### Handling CheckSecondaryLocksRequest
+
+The server iterates over the keys in the request. For each key, the server checks the status of the key. If we find a pessimistic lock, it is unlocked. If the key has been rolled back (either in handling this request or previously) or committed, then we return that to the client and stop checking keys. If all keys are locked by the expected transaction, then a list of the locks is sent to the client. Furthermore, for the first unlocked key, we will write a rollback record if necessary and wake up another job waiting on the lock.
+
+Whenever we rollback a transaction (either here or when handling `CheckTransactionStatus`), we must take care with the situation where we rollback a key which has already been locked by another transaction (for example, if the original prewrite message were lost). If that transaction is committed, then it might 'over-write' our rollback record. To handle this, we add our start ts to the lock's `rollback_ts` list, if the lock is committed all entries in `rollback_ts` are written as rollback records to the write CF.
+
+### Handling `CheckTransactionStatusRequest` and `ResolveLockRequest`
+
+The protocol for handling locked keys is different for async commit transactions and regular transactions.
+
+For regular transactions, the client will send a `CheckTransactionStatusRequest`to query the primary lock and (if the TTL has expired) rollback the lock or push forward its `min_commit_ts` . Then `ResolveLockRequest` is sent to unlock secondary keys.
+
+For async commit transactions, the client will use `CheckTransactionStatusRequest` to query the primary lock, then `CheckSecondaryLocksRequest` to check the secondary locks, and then `ResolveLockRequest` to either commit or rollback both primary and secondary locks.
+
+Therefore, when handling `CheckTransactionStatusRequest`s, the server must take care not to change the locks belonging to an async commit transaction.
+
+
 ## CDC
 
+TODO
+
+TODO CDC endpoint in tikv - global_min_lock_ts
+
 ## TiFlash
+
+TODO

--- a/design/async-commit/spec.md
+++ b/design/async-commit/spec.md
@@ -68,7 +68,7 @@ message LockInfo {
 
 Implemented in TiDB, TiSpark.
 
-The client has configuration for supporting async commit (`tikv-client.async-commit.enable`), supporting 1pc (`enable-one-pc`), forcing external consistency when using async commit (`external-consistency`), and limits on the size (`tikv-client.async-commit.total-key-size-limit`) and number of keys (`tikv-client.async-commit.keys-limit`) in an async commit transaction. When async commit is enabled, a transaction will not use async commit if it exceeds either of the size limits.
+The client has system variables for supporting async commit (`tidb_enable_async_commit`), supporting 1pc (`tidb_enable_1pc`), and forcing external consistency when using async commit (`tidb_guarantee_external_consistency`). The client has configuration options for setting the limits on the size (`tikv-client.async-commit.total-key-size-limit`) and number of keys (`tikv-client.async-commit.keys-limit`) in an async commit transaction. When async commit is enabled, a transaction will not use async commit if it exceeds either of the size limits.
 
 TODO prewrite and commit
 
@@ -92,7 +92,7 @@ If `max_ts` has become out of date (due to some change to the region topology), 
 
 The server iterates over all keys in the request. If a key is locked for async commit by the current transaction, and it is no longer an async commit transaction, then the lock can be overwritten. Each key is locked; for 1pc the lock is kept privately in memory, for 2pc the lock is written to storage. In either case the lock is also kept in memory by the concurrency manager. These in-memory locks are used to block reading while the transaction is live.
 
-The `min_commit_ts` for the key is calculated as the maximum of the transaction's start ts, `for_update_ts`, and `min_commit_ts`, and the `max_ts` of the store. The `min_commit_ts` is written to the lock. The largest `min_commit_ts` of all keys is returned to the client.
+The `min_commit_ts` for the key is calculated as the maximum of the transaction's `start_ts + 1`, `for_update_ts + 1`, and `min_commit_ts`, and the `max_ts + 1` of the store. The `min_commit_ts` is written to the lock. The largest `min_commit_ts` of all keys is returned to the client.
 
 Finally, if this is a 1pc transaction, then all writes are committed and any locks are released.
     

--- a/design/async-commit/spec.md
+++ b/design/async-commit/spec.md
@@ -1,0 +1,77 @@
+# Async commit design spec
+
+Includes one phase commit (1pc).
+
+## Protocol
+
+### Commit
+
+The transaction is composed as usual. When prewriting, the client can set `use_async_commit` and/or `try_one_pc` to use async commit or 1pc, respectively. If using async commit, the client must specify all keys other than the primary key in the message sent to the region containing the primary key (in `secondaries`).
+
+If async commit was used, the response will include a non-zero `min_commit_ts`. If 1pc was used, it will include a non-zero `one_pc_commit_ts`. If either was used, then success can be returned to the client if all prewrites succeed. In the case of 1pc, there are no commit messages. For async commit, they are all sent asynchronously.
+
+`max_commit_ts` in `PrewriteRequest` and the `CommitTsTooLarge` error are used to support schema checking. See the TiDB section below.
+
+```
+message PrewriteRequest {
+    ...
+    bool use_async_commit = 11;
+    repeated bytes secondaries = 12;
+    bool try_one_pc = 13;
+    uint64 max_commit_ts = 14;
+}
+
+message PrewriteResponse {
+    ...
+    uint64 min_commit_ts = 3;
+    uint64 one_pc_commit_ts = 4;
+}
+
+message KeyError {
+    ...
+    CommitTsTooLarge commit_ts_too_large = 9;
+}
+
+message CommitTsTooLarge {
+    uint64 commit_ts = 1; // The calculated commit TS.
+}
+
+```
+
+### Recovery
+
+The recovery workflow is necessary when a transaction encounters a lock from an async commit transaction. When the server encounters such a Lock, it returns a `KeyError::locked` error. The client can check `use_async_commit` to see if it must follow the async commit recovery protocol. If so, it sends a `CheckTxnStatusRequest` to the primary's store, and will get a list of the secondaries in the returned lock info. The client must send a `CheckSecondaryLocksRequest` to each region to cover all secondary keys. If all are locked or any are committed, then the transaction succeeded and the client can commit all the keys. If any have failed, then the transaction can be rolled back for all keys.
+
+```
+message CheckSecondaryLocksRequest {
+    Context context = 1;
+    repeated bytes keys = 2;
+    uint64 start_version = 3;
+}
+
+message CheckSecondaryLocksResponse {
+    errorpb.Error region_error = 1;
+    KeyError error = 2;
+    repeated LockInfo locks = 3;
+    uint64 commit_ts = 4;
+}
+
+message LockInfo {
+    ...
+    bool use_async_commit = 8;
+    uint64 min_commit_ts = 9;
+    repeated bytes secondaries = 10;
+}
+```
+
+## Clients
+
+Implemented in TiDB, TiSpark.
+
+## Server
+
+Implemented in TiKV
+
+## CDC
+
+## TiFlash


### PR DESCRIPTION
This PR brings some of the project documentation up to date for async commit and starts a detailed technical description of the feature. There is still much work to do in the design spec, but I think we can land it now to make collaboration easier.

PTAL @sticnarf 